### PR TITLE
fix: Resolve website break issue when updating plugin documentation titles

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -110,7 +110,7 @@ const createAsciiDocPages = async({createPage, graphql, reporter}) => {
     return;
   }
   result.data.allAsciidocCopy.edges.forEach(({ node }) => {
-    const slug = `/docs/${node.document.title.replace(/(.*\/)?/, '')}`;
+    const slug = `/docs/${node.document.title.replace(/(.*\/ ?)?/, '')}`;
     createPage({
       path: slug,
       component: docTemplate,


### PR DESCRIPTION
fix for https://github.com/eclipse/jkube/pull/2861#issuecomment-2027319739